### PR TITLE
Support all gcr-cleaner parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 <a name="unreleased"></a>
 ## [Unreleased]
-
+Enhancements:
+- Support all [payload parameters](https://github.com/sethvargo/gcr-cleaner#payload--parameters)
 
 
 <a name="v0.6.0"></a>

--- a/main.tf
+++ b/main.tf
@@ -81,9 +81,19 @@ resource "google_cloud_scheduler_job" "this" {
   http_target {
     http_method = "POST"
     uri         = "${google_cloud_run_service.this.status[0].url}/http"
-    # TODO implement all payload parameters
-    # https://github.com/sethvargo/gcr-cleaner#payload--parameters
-    body = base64encode(jsonencode(tomap({ "repo" = each.value })))
+    body = base64encode(
+      jsonencode(
+        {
+          "allow_tagged" : var.gcr_cleaner_allow_tagged,
+          "dry_run" : var.gcr_cleaner_dry_run,
+          "grace" = var.gcr_cleaner_grace,
+          "keep" : var.gcr_cleaner_keep,
+          "recursive" : var.gcr_cleaner_recursive,
+          "repo" = each.value,
+          "tag_filter" : var.gcr_cleaner_tag_filter,
+        }
+      )
+    )
     oidc_token {
       service_account_email = google_service_account.invoker.email
     }

--- a/variables.tf
+++ b/variables.tf
@@ -56,6 +56,35 @@ variable "gcr_cleaner_image" {
   }
 }
 
+variable "gcr_cleaner_allow_tagged" {
+  description = "If set to true, will check all images including tagged. If unspecified, the default will only delete untagged images."
+  type        = bool
+  default     = false
+}
+
+variable "gcr_cleaner_dry_run" {
+  description = "If set to true, will not delete anything and outputs what would have been deleted."
+  type        = bool
+  default     = false
+}
+
+variable "gcr_cleaner_grace" {
+  description = "Amount of grace to allow when deleting images, eg 24h will not delete younger than 24 hours."
+  type        = string
+  default     = "0h"
+}
+
+variable "gcr_cleaner_keep" {
+  description = "If an integer is provided, it will always keep that minimum number of images. Note that it will not consider images inside the grace duration."
+  type        = number
+  default     = 0
+}
+variable "gcr_cleaner_recursive" {
+  description = "If set to true, will recursively search all child repositories."
+  type        = bool
+  default     = false
+}
+
 variable "gcr_repositories" {
   description = "List of Google Container Registries objects."
   type = list(object({
@@ -77,6 +106,12 @@ variable "gcr_repositories" {
     ]) == 0 : true
     error_message = "One of the repositories in the list doesn't match the requirements. You have to provide repositories or clean_all, not both at the same time or none of them."
   }
+}
+
+variable "gcr_cleaner_tag_filter" {
+  description = "Used for tags regexp definition to define pattern to clean."
+  type        = string
+  default     = ""
 }
 
 variable "cloud_scheduler_job_schedule" {


### PR DESCRIPTION
I noticied you had a comment in the module stating that you wanted to add the missing payload parameters at some point. We ran in to a situation where we needed them so I went ahead and implemented the change and where we are :)

I've tried to have the module default to the zero-values used in gcr-cleaner, so even though this change will now set all parameters even if you don't specify any to the module, their default values should be safe.
