### PR TITLE
add serviceAccountUser permission when terraform is running as a service-account

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -13,3 +13,5 @@ data "external" "this" {
     google_project_id = each.value.google_project_id
   }
 }
+
+data "google_client_openid_userinfo" "terraform" {}

--- a/iam.tf
+++ b/iam.tf
@@ -18,3 +18,23 @@ resource "google_cloud_run_service_iam_binding" "this" {
     "serviceAccount:${google_service_account.invoker.email}"
   ]
 }
+
+# Allow the account that is running terraform permissions to act-as
+# the service-account, required for deploying a CloudRun service
+resource "google_service_account_iam_member" "tf-cleaner" {
+  count = local.running_as_a_service_account ? 1 : 0
+
+  service_account_id = google_service_account.cleaner.name
+  role               = "roles/iam.serviceAccountUser"
+  member             = "serviceAccount:${data.google_client_openid_userinfo.terraform.email}"
+}
+
+# Allow the account that is running terraform permissions to act-as
+# the service-account, required for deploying a CloudScheduler service
+resource "google_service_account_iam_member" "tf-invoker" {
+  count = local.running_as_a_service_account ? 1 : 0
+
+  service_account_id = google_service_account.invoker.name
+  role               = "roles/iam.serviceAccountUser"
+  member             = "serviceAccount:${data.google_client_openid_userinfo.terraform.email}"
+}

--- a/locals.tf
+++ b/locals.tf
@@ -31,4 +31,6 @@ locals {
       for repo in jsondecode(data.result.repositories) : repo
     ]
   ])
+
+  running_as_a_service_account = length(regexall(".*@.*[.]gserviceaccount[.]com", data.google_client_openid_userinfo.terraform.email)) > 0
 }


### PR DESCRIPTION
The `iam.serviceAccountUser` role is necessary when deploying a cloud-run service or cloud-scheduler job.

Granting this at project level is very broad and is [considered unsafe](https://cloud.google.com/security-command-center/docs/how-to-remediate-security-health-analytics-findings#over_privileged_service_account_user).

When terraform is running as a service-account the module will explicitly the `iam.serviceAccountUser` role on the invoker and cleaner SAs to the account that is running terraform.