### PR TITLE
fix(idempotency): label changed on each plan

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -10,6 +10,10 @@ resource "google_cloud_run_service" "this" {
         "autoscaling.knative.dev/maxScale" = var.cloud_run_service_maximum_instances
         "run.googleapis.com/client-name"   = "cloud-scheduler"
       }
+      
+      labels = {
+        "run.googleapis.com/startupProbeType" = "Default"
+      }
     }
 
     spec {


### PR DESCRIPTION
# fix idempotency

## Description

Each time you do a plan their is a change removing a label so I added the label on the configuration

```tf
 # module.gcr_cleaner.google_cloud_run_service.this will be updated in-place
  ~ resource "google_cloud_run_service" "this" {
        id                         = "locations/europe-west1/namespaces/xxx/services/gcr-cleaner"
        name                       = "gcr-cleaner"
        # (4 unchanged attributes hidden)
      ~ template {
          ~ metadata {
              ~ labels      = {
                  - "run.googleapis.com/startupProbeType" = "Default" -> null
                }
```

## Type of change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] My PR title follows [semantics prefix](.github/CONTRIBUTING.md#semantic-pull-requests)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
- [ ] I have run pre-commit hooks `pre-commit run -a`
- [ ] CI tests are passing
